### PR TITLE
Reverse proxy ACME HTTP challenge requests to rise-server

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -66,6 +66,13 @@ http {
       root nginx/custom_html;
     }
 
+    # Reverse proxy Let's Encrypt HTTP challenge verification requests to
+    # rise-server.
+    location /.well-known/acme-challenge/ {
+      # In prod, this should point to rise-server.
+      proxy_pass http://127.0.0.1:3000;
+    }
+
     location @404 {
       access_log off;
       error_log off;
@@ -81,6 +88,8 @@ http {
   server {
     set $rise_prefix "";
     listen 8443 ssl;
+
+    access_log /dev/stdout;
 
     ssl_certificate /opt/openresty/nginx/certs/star.risecloud.dev.crt;
     ssl_certificate_key /opt/openresty/nginx/certs/star.risecloud.dev.key;


### PR DESCRIPTION
Let's Encrypt will make a request to `$users_domain/.well-known/acme-challenge/$token` to verify ownership of a domain, so we reverse proxy the response from rise-server (see https://github.com/nitrous-io/rise-server/pull/45) which will serve the challenge response.

This does centralize the challenge verification so I'm not sure if this is better than simply uploading a `/.well-known/acme-challenge/$token` file to S3.
